### PR TITLE
Fix plugin crashes caused by user input

### DIFF
--- a/src/com/pablo67340/shop/GUIShop.java
+++ b/src/com/pablo67340/shop/GUIShop.java
@@ -125,7 +125,7 @@ public class GUIShop extends JavaPlugin implements Listener{
 	public void onInteract(PlayerInteractEvent e) {
 		Player player = e.getPlayer();
 		Block block = e.getClickedBlock();
-		if(block.getState() instanceof Sign) {
+		if(block != null && block.getState() instanceof Sign) {
 			Sign sign = (Sign) block.getState();
 			String line1 = ChatColor.translateAlternateColorCodes('&',sign.getLine(0));
 			if (verbose){

--- a/src/com/pablo67340/shop/GUIShop.java
+++ b/src/com/pablo67340/shop/GUIShop.java
@@ -712,7 +712,7 @@ public class GUIShop extends JavaPlugin implements Listener{
 		if (verbose){
 			System.out.println("TrySell: "+item.getTypeId());
 		}
-		if (((item != null) || (item == null)) && (!item.getItemMeta().hasLore()) && (p.getInventory().contains(item)))
+		if (item != null && item.getItemMeta() != null && !item.getItemMeta().hasLore() && p.getInventory().contains(item))
 		{
 			if (verbose){
 				System.out.println("Item passed secondary checks!");


### PR DESCRIPTION
I've been experiencing crashes whenever a user right clicked while not looking at a block and when they clicked on an empty inventory slot while trying to sell.
