### PR TITLE
Fix the null error when clicking on an empty slot

### DIFF
--- a/src/com/pablo67340/guishop/listenable/Shop.java
+++ b/src/com/pablo67340/guishop/listenable/Shop.java
@@ -376,6 +376,9 @@ public class Shop {
 		if (e.getClickedInventory() == null) {
 			return;
 		}
+		ItemStack CurrentItem = e.getCurrentItem(); //Vital to not cause the null click error when clicking on an empty slot
+		if (CurrentItem == null){
+			return;
 
 		// Forward Button
 		Main.debugLog("Clicked: " + e.getSlot());


### PR DESCRIPTION
3 lines of code to fix the null pointer error when clicking on an empty slot in the GUIshop menu.