### PR TITLE
Configuration Defaults , Alternate Sell GUI per request, Potion Type Changes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -45,6 +45,9 @@ disabled-world: '&cYou cannot use the shop from this world!'
 #Use the escape key to close the shop instead of the back button.
 escape-only: true
 
+#Rightclick an item in the shop to open an alternate sell GUI
+alternate-sell-enable: false
+
 #The message for the amount you lose, E.G Cost, Or Price
 cost: '&7Price'
 
@@ -151,6 +154,9 @@ sell-title: "Menu &f> &rSell"
 #The title of the quantity inventory.
 qty-title: "&4Select Amount"
 
+#The title of the alternate sell GUI, if enabled
+alt-sell-title: "Menu &f> &rSell"
+
 access-to: "&aAccess to Commands:"
 
 buy-lore: "&fBuy: &c{amount}"
@@ -166,6 +172,24 @@ cannot-sell: "&cCannot Sell"
 forward-page-button-name: "&rNext page"
 
 backward-page-button-name: "&rLast page"
+
+#Used in the alternate sell GUI
+alt-sell-indicator-material: 'GOLD_INGOT'
+
+alt-sell-add-material: 'GREEN_STAINED_GLASS_PANE'
+alt-sell-remove-material: 'RED_STAINED_GLASS_PANE'
+
+alt-sell-quantity-1: 1
+alt-sell-quantity-2: 10
+alt-sell-quantity-3: 64
+
+alt-sell-confirm-material: 'EMERALD_BLOCK'
+alt-sell-cancel-material: 'REDSTONE_BLOCK'
+
+alt-sell-confirm-name: '&a&lConfirm'
+alt-sell-cancel-name: '&c&lCancel'
+
+alt-sell-not-enough: '&cYou do not have {amount} such items to sell.'
 
 DisabledWorlds:
     -'Test'

--- a/shops.yml
+++ b/shops.yml
@@ -359,18 +359,22 @@ Brewing:
     type: SHOP
     id: POTION
     buy-price: 10.0
-    shop-name: '&fVanilla strength potion'
+    shop-name: '&fPotion of prolonged strength'
     potion-info:
       type: 'STRENGTH'
+      splash: false
+      extended: true
+      amplifier: 1
   '10':
     type: SHOP
     id: POTION
     buy-price: 10.0
-    shop-name: '&fPoison IV for 30 seconds'
+    shop-name: '&fSplash potion of Poison II'
     potion-info:
       type: 'POISON'
-      duration: 30
-      amplifier: 4
+      splash: true
+      extended: false
+      amplifier: 2
 Gear:
   '0':
     type: SHOP

--- a/src/com/pablo67340/guishop/Main.java
+++ b/src/com/pablo67340/guishop/Main.java
@@ -288,6 +288,7 @@ public final class Main extends JavaPlugin {
 		Config.setCantSell(ChatColor.translateAlternateColorCodes('&',
 				Objects.requireNonNull(getMainConfig().getString("cant-sell"))));
 		Config.setEscapeOnly(getMainConfig().getBoolean("escape-only"));
+		Config.setAlternateSellEnabled(getMainConfig().getBoolean("alternate-sell-enable", false));
 		Config.setSound(getMainConfig().getString("purchase-sound"));
 		Config.setSoundEnabled(getMainConfig().getBoolean("enable-sound"));
 		Config.setEnableCreator(getMainConfig().getBoolean("ingame-config"));
@@ -307,6 +308,8 @@ public final class Main extends JavaPlugin {
 				getMainConfig().getString("shop-title", "Menu &f> &r{shopname}")));
 		Config.setSellTitle(ChatColor.translateAlternateColorCodes('&',
 				Objects.requireNonNull(getMainConfig().getString("sell-title"))));
+		Config.setAltSellTitle(ChatColor.translateAlternateColorCodes('&',
+				getMainConfig().getString("alt-sell-title", "Menu &f> &rSell")));
 		Config.setQtyTitle(ChatColor.translateAlternateColorCodes('&',
 				Objects.requireNonNull(getMainConfig().getString("qty-title"))));
 		Config.setBackButtonItem(ChatColor.translateAlternateColorCodes('&',
@@ -328,6 +331,20 @@ public final class Main extends JavaPlugin {
 				ChatColor.translateAlternateColorCodes('&', getMainConfig().getString("forward-page-button-name", "")));
 		Config.setBackwardPageButtonName(
 				ChatColor.translateAlternateColorCodes('&', getMainConfig().getString("backward-page-button-name", "")));
+		Config.setAltSellIndicatorMaterial(getMainConfig().getString("alt-sell-indicator-material", "EMERALD"));
+		Config.setAltSellAddMaterial(getMainConfig().getString("alt-sell-add-material", "GREEN_STAINED_GLASS_PANE"));
+		Config.setAltSellRemoveMaterial(getMainConfig().getString("alt-sell-remove-material", "RED_STAINED_GLASS_PANE"));
+		Config.setAltSellQuantity1(getMainConfig().getInt("alt-sell-quantity-1", 1));
+		Config.setAltSellQuantity2(getMainConfig().getInt("alt-sell-quantity-2", 10));
+		Config.setAltSellQuantity3(getMainConfig().getInt("alt-sell-quantity-3", 64));
+		Config.setAltSellConfirmMaterial(getMainConfig().getString("alt-sell-confirm-material", "EMERALD_BLOCK"));
+		Config.setAltSellCancelMaterial(getMainConfig().getString("alt-sell-cancel-material", "REDSTONE_BLOCK"));
+		Config.setAltSellConfirmName(ChatColor.translateAlternateColorCodes('&',
+				getMainConfig().getString("alt-sell-confirm-name", "&a&lConfirm")));
+		Config.setAltSellCancelName(ChatColor.translateAlternateColorCodes('&',
+				getMainConfig().getString("alt-sell-cancel-name", "&c&lCancel")));
+		Config.setAltSellNotEnough(ChatColor.translateAlternateColorCodes('&',
+				getMainConfig().getString("alt-sell-not-enough", "&cYou do not have enough items to sell.")));
 		Config.getDisabledQty().addAll(getMainConfig().getStringList("disabled-qty-items"));
 		Config.setDynamicPricing(getMainConfig().getBoolean("dynamic-pricing", false));
 		Config.setDebugMode(getMainConfig().getBoolean("debug-mode"));

--- a/src/com/pablo67340/guishop/Main.java
+++ b/src/com/pablo67340/guishop/Main.java
@@ -431,6 +431,9 @@ public final class Main extends JavaPlugin {
 		reloadCustomConfig();
 		loadDefaults();
 		loadShopDefs();
+		if (Config.isRegisterCommands()) {
+			registerCommands();
+		}
 		sendMessage(player, "&aGUIShop Reloaded");
 
 	}

--- a/src/com/pablo67340/guishop/Main.java
+++ b/src/com/pablo67340/guishop/Main.java
@@ -367,8 +367,9 @@ public final class Main extends JavaPlugin {
 				if (item.isAnyPotion()) {
 					ConfigurationSection potionSection = section.getConfigurationSection("potion-info");
 					if (potionSection != null) {
-						item.setAndParsePotionType(potionSection.getString("type"),
-								potionSection.getInt("duration", -1), potionSection.getInt("amplifier", -1));
+						item.parsePotionType(potionSection.getString("type"),
+								potionSection.getBoolean("splash", false),
+								potionSection.getBoolean("extended", false), potionSection.getInt("amplifier", -1));
 					}
 				}
 				item.setMobType((section.contains("mobType") ? (String) section.get("mobType") : "PIG"));

--- a/src/com/pablo67340/guishop/Main.java
+++ b/src/com/pablo67340/guishop/Main.java
@@ -302,12 +302,12 @@ public final class Main extends JavaPlugin {
 		Config.setCurrency(getMainConfig().getString("currency"));
 		Config.setCurrencySuffix(ChatColor.translateAlternateColorCodes('&',
 				Objects.requireNonNull(getMainConfig().getString("currency-suffix"))));
-		Config.setMenuTitle(
-				ChatColor.translateAlternateColorCodes('&', getMainConfig().getString("menu-title", "Menu")));
+		Config.setMenuTitle(ChatColor.translateAlternateColorCodes('&',
+				getMainConfig().getString("menu-title", "Menu")));
 		Config.setShopTitle(ChatColor.translateAlternateColorCodes('&',
 				getMainConfig().getString("shop-title", "Menu &f> &r{shopname}")));
 		Config.setSellTitle(ChatColor.translateAlternateColorCodes('&',
-				Objects.requireNonNull(getMainConfig().getString("sell-title"))));
+				getMainConfig().getString("sell-title", "Menu &f> &rSell")));
 		Config.setAltSellTitle(ChatColor.translateAlternateColorCodes('&',
 				getMainConfig().getString("alt-sell-title", "Menu &f> &rSell")));
 		Config.setQtyTitle(ChatColor.translateAlternateColorCodes('&',

--- a/src/com/pablo67340/guishop/Main.java
+++ b/src/com/pablo67340/guishop/Main.java
@@ -426,6 +426,21 @@ public final class Main extends JavaPlugin {
 			e.printStackTrace();
 		}
 	}
+	
+	/**
+	 * Formats money using the economy plugin's significant digits. <br>
+	 * <i>Does not add currency prefixes or suffixes. </i> <br>
+	 * <br>
+	 * Example: 2.4193 -> 2.42 <br>
+	 * Prevents scientific notation being displayed on items.
+	 * 
+	 * @param value what to format
+	 * @return the formatted result
+	 */
+	public static String economyFormat(double value) {
+		int digits = ECONOMY.fractionalDigits();
+		return (digits == -1) ? Double.toString(value) : String.format("%." + digits + "f", value);
+	}
 
 	public static String placeholderIfy(String input, Player player, Item item) {
 		String str = input;

--- a/src/com/pablo67340/guishop/definition/AltSellPane.java
+++ b/src/com/pablo67340/guishop/definition/AltSellPane.java
@@ -1,0 +1,88 @@
+package com.pablo67340.guishop.definition;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+import com.github.stefvanschie.inventoryframework.Gui;
+import com.github.stefvanschie.inventoryframework.GuiItem;
+import com.github.stefvanschie.inventoryframework.pane.Pane;
+
+import lombok.Getter;
+
+public class AltSellPane extends Pane {
+
+	private List<GuiItem> items = new ArrayList<>();
+	
+	@Getter
+	private int subjectQuantity;
+	
+	public AltSellPane(GuiItem subjectItem, GuiItem[] addRemoveItems, GuiItem indicatorItem, GuiItem confirmItem, GuiItem cancelItem) {
+		super(9, 6);
+		items.add(subjectItem);
+		for (int n = 0; n < 6; n++) {
+			items.add(addRemoveItems[n]);
+		}
+		items.add(indicatorItem);
+		items.add(confirmItem);
+		items.add(cancelItem);
+	}
+	
+	public int setSubjectQuantity(int subjectQuantity) {
+		ItemStack subjectItem = items.get(0).getItem().clone();
+		if (subjectQuantity > subjectItem.getMaxStackSize()) {
+			subjectQuantity = subjectItem.getMaxStackSize();
+		}
+		subjectItem.setAmount(subjectQuantity);
+		items.set(0, new GuiItem(subjectItem));
+		this.subjectQuantity = subjectQuantity;
+		return subjectQuantity;
+	}
+	
+	public void setIndicatorName(String name) {
+		items.set(7, Item.renameGuiItem(items.get(7), name));
+	}
+	
+	@Override
+	public void display(Gui gui, Inventory inventory, PlayerInventory playerInventory, int paneOffsetX, int paneOffsetY,
+			int maxLength, int maxHeight) {
+		inventory.setItem(13, items.get(0).getItem());
+		inventory.setItem(18, items.get(1).getItem());
+		inventory.setItem(19, items.get(2).getItem());
+		inventory.setItem(20, items.get(3).getItem());
+		inventory.setItem(24, items.get(4).getItem());
+		inventory.setItem(25, items.get(5).getItem());
+		inventory.setItem(26, items.get(6).getItem());
+		inventory.setItem(31, items.get(7).getItem());
+		inventory.setItem(48, items.get(8).getItem());
+		inventory.setItem(50, items.get(9).getItem());
+	}
+
+	@Override
+	public boolean click(Gui gui, InventoryClickEvent event, int paneOffsetX, int paneOffsetY, int maxLength,
+			int maxHeight) {
+		return false;
+	}
+
+	@Override
+	public Collection<GuiItem> getItems() {
+		return new ArrayList<>(items);
+	}
+
+	@Override
+	public Collection<Pane> getPanes() {
+		return new HashSet<>();
+	}
+
+	@Override
+	public void clear() {
+		items.clear();
+	}
+
+}

--- a/src/com/pablo67340/guishop/definition/Item.java
+++ b/src/com/pablo67340/guishop/definition/Item.java
@@ -366,7 +366,7 @@ public final class Item {
 			if (buyPriceAsDouble != 0) {
 
 				return Config.getBuyLore().replace("{amount}",
-						Config.getCurrency() + calculateBuyPrice(quantity) + Config.getCurrencySuffix());
+						Config.getCurrency() + Main.economyFormat(calculateBuyPrice(quantity)) + Config.getCurrencySuffix());
 			}
 			return Config.getFreeLore();
 		}
@@ -386,7 +386,7 @@ public final class Item {
 	public String getSellLore(int quantity) {
 		if (hasSellPrice()) {
 			return Config.getSellLore().replace("{amount}",
-					Config.getCurrency() + calculateSellPrice(quantity) + Config.getCurrencySuffix());
+					Config.getCurrency() + Main.economyFormat(calculateSellPrice(quantity)) + Config.getCurrencySuffix());
 		}
 		return Config.getCannotSell();
 	}

--- a/src/com/pablo67340/guishop/definition/Item.java
+++ b/src/com/pablo67340/guishop/definition/Item.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionEffect;
@@ -549,6 +550,21 @@ public final class Item {
 
 		Main.debugLog("Failed to find entity type using EntityType#valueOf");
 		return null;
+	}
+	
+	/**
+	 * Renames a GuiItem
+	 * 
+	 * @param gItem the gui item
+	 * @param name the new name
+	 * @return an updated gui item
+	 */
+	public static GuiItem renameGuiItem(GuiItem gItem, String name) {
+		ItemStack item = gItem.getItem().clone();
+		ItemMeta itemMeta = item.getItemMeta();
+		itemMeta.setDisplayName(name);
+		item.setItemMeta(itemMeta);
+		return new GuiItem(item);
 	}
 
 }

--- a/src/com/pablo67340/guishop/listenable/AltSell.java
+++ b/src/com/pablo67340/guishop/listenable/AltSell.java
@@ -105,7 +105,8 @@ public class AltSell {
 		if (result.isEmpty()) {
 
 			Sell.roundAndGiveMoney(player, subjectItem.calculateSellPrice(amount));
-			if (Config.isDynamicPricing()) {
+			// buy price must be defined for dynamic pricing to work
+			if (subjectItem.hasBuyPrice() && Config.isDynamicPricing()) {
 				Main.getDYNAMICPRICING().sellItem(subjectItem.getItemString(), amount);
 			}
 		} else {

--- a/src/com/pablo67340/guishop/listenable/AltSell.java
+++ b/src/com/pablo67340/guishop/listenable/AltSell.java
@@ -1,0 +1,145 @@
+package com.pablo67340.guishop.listenable;
+
+import java.util.Map;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+
+import com.github.stefvanschie.inventoryframework.Gui;
+import com.github.stefvanschie.inventoryframework.GuiItem;
+import com.github.stefvanschie.inventoryframework.shade.mininbt.ItemNBTUtil;
+import com.github.stefvanschie.inventoryframework.shade.mininbt.NBTWrappers.NBTTagCompound;
+import com.pablo67340.guishop.Main;
+import com.pablo67340.guishop.definition.AltSellPane;
+import com.pablo67340.guishop.definition.Item;
+import com.pablo67340.guishop.util.Config;
+
+public class AltSell {
+
+	private final Item subjectItem;
+	private final Gui gui;
+
+	private AltSellPane pane;
+	
+	private final Item indicatorItem;
+	private final Item addItem;
+	private final Item removeItem;
+	private final Item confirmItem;
+	private final Item cancelItem;
+	
+	public AltSell(Item subjectItem) {
+		this.subjectItem = subjectItem;
+		gui = new Gui(Main.getINSTANCE(), 6, ChatColor.translateAlternateColorCodes('&', Config.getAltSellTitle()));
+		indicatorItem = new Item();
+		indicatorItem.setMaterial(Config.getAltSellIndicatorMaterial());
+		addItem = new Item();
+		addItem.setMaterial(Config.getAltSellAddMaterial());
+		removeItem = new Item();
+		removeItem.setMaterial(Config.getAltSellRemoveMaterial());
+		confirmItem = new Item();
+		confirmItem.setMaterial(Config.getAltSellConfirmMaterial());
+		cancelItem = new Item();
+		cancelItem.setMaterial(Config.getAltSellCancelMaterial());
+	}
+	
+	private GuiItem setQuantityAndGet(ItemStack item, int quantity) {
+		item.setAmount(quantity);
+		return new GuiItem(item);
+	}
+	
+	public void open(Player player) {
+		GuiItem gItem = subjectItem.parseMaterial();
+		GuiItem gIndicator = indicatorItem.parseMaterial();
+		GuiItem gAddItem = addItem.parseMaterial();
+		GuiItem gRemoveItem = removeItem.parseMaterial();
+		GuiItem gConfirmItem = confirmItem.parseMaterial();
+		GuiItem gCancelItem = cancelItem.parseMaterial();
+		if (gItem != null && gIndicator != null && gAddItem != null && gRemoveItem != null && gConfirmItem != null && gCancelItem != null) {
+			GuiItem[] addRemoveItems = new GuiItem[6];
+			ItemStack addItem = gAddItem.getItem();
+			addRemoveItems[0] = setQuantityAndGet(addItem.clone(), Config.getAltSellQuantity1());
+			addRemoveItems[1] = setQuantityAndGet(addItem.clone(), Config.getAltSellQuantity2());
+			addRemoveItems[2] = setQuantityAndGet(addItem.clone(), Config.getAltSellQuantity3());
+			ItemStack removeItem = gRemoveItem.getItem();
+			addRemoveItems[3] = setQuantityAndGet(removeItem.clone(), Config.getAltSellQuantity1());
+			addRemoveItems[4] = setQuantityAndGet(removeItem.clone(), Config.getAltSellQuantity2());
+			addRemoveItems[5] = setQuantityAndGet(removeItem.clone(), Config.getAltSellQuantity3());
+			pane = new AltSellPane(gItem, addRemoveItems, gIndicator,
+					Item.renameGuiItem(gConfirmItem, Config.getAltSellConfirmName()), Item.renameGuiItem(gCancelItem, Config.getAltSellCancelName()));
+			pane.setSubjectQuantity(1);
+			pane.setIndicatorName(subjectItem.getSellLore(1));
+			gui.addPane(pane);
+			gui.setOnTopClick(this::onClick);
+			gui.setOnBottomClick(event -> event.setCancelled(true));
+			gui.show(player);
+		} else {
+			Main.log("One or more of the materials you defined in the alt sell GUI are not valid.");
+		}
+	}
+	
+	private void changeQuantity(int delta) {
+		int previous = pane.getSubjectQuantity();
+		int update = previous + delta;
+		if (update < 1) {
+			update = 1;
+		}
+		update = pane.setSubjectQuantity(update);
+		if (update != previous) {
+			pane.setIndicatorName(subjectItem.getSellLore(update));
+			gui.update();
+		}
+	}
+	
+	private void sell(Player player, ItemStack itemStack) {
+		// remove IF's IF-uuid NBT tag
+		NBTTagCompound comp = ItemNBTUtil.getTag(itemStack);
+		comp.remove("IF-uuid");
+		itemStack = ItemNBTUtil.setNBTTag(comp, itemStack);
+
+		Main.debugLog(itemStack.toString());
+
+		int amount = itemStack.getAmount();
+		Map<Integer, ItemStack> result = player.getInventory().removeItem(itemStack);
+		if (result.isEmpty()) {
+
+			Sell.roundAndGiveMoney(player, subjectItem.calculateSellPrice(amount));
+			if (Config.isDynamicPricing()) {
+				Main.getDYNAMICPRICING().sellItem(subjectItem.getItemString(), amount);
+			}
+		} else {
+			ItemStack addBack = result.get(0).clone();
+			addBack.setAmount(amount - addBack.getAmount());
+			if (addBack.getAmount() > 0) {
+				player.getInventory().addItem(addBack);
+			}
+			player.sendMessage(Config.getAltSellNotEnough().replace("{amount}", Integer.toString(amount)));
+		}
+	}
+	
+	private void onClick(InventoryClickEvent evt) {
+		evt.setCancelled(true);
+		switch (evt.getSlot()) {
+		case 18:
+		case 19:
+		case 20:
+			changeQuantity(evt.getCurrentItem().getAmount());
+			break;
+		case 24:
+		case 25:
+		case 26:
+			changeQuantity(-evt.getCurrentItem().getAmount());
+			break;
+		case 48:
+			sell((Player) evt.getWhoClicked(), evt.getInventory().getItem(13));
+			break;
+		case 50:
+			evt.getWhoClicked().closeInventory();
+			break;
+		default:
+			break;
+		}
+	}
+	
+}

--- a/src/com/pablo67340/guishop/listenable/Quantity.java
+++ b/src/com/pablo67340/guishop/listenable/Quantity.java
@@ -15,7 +15,6 @@ import org.bukkit.inventory.ItemStack;
 
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.scheduler.BukkitScheduler;
 
 import com.github.stefvanschie.inventoryframework.Gui;
@@ -88,8 +87,8 @@ class Quantity {
 
 			ItemStack itemStack = gItem.getItem();
 
-			gItem.getItem().setAmount(multiplier);
-			ItemMeta itemMeta = gItem.getItem().getItemMeta();
+			itemStack.setAmount(multiplier);
+			ItemMeta itemMeta = itemStack.getItemMeta();
 			List<String> lore = new ArrayList<>();
 
 			lore.add(item.getBuyLore(multiplier));
@@ -123,18 +122,18 @@ class Quantity {
 					for (String enc : item.getEnchantments()) {
 						String enchantment = StringUtils.substringBefore(enc, ":");
 						String level = StringUtils.substringAfter(enc, ":");
-						gItem.getItem().addUnsafeEnchantment(
+						itemStack.addUnsafeEnchantment(
 								XEnchantment.matchXEnchantment(enchantment).get().parseEnchantment(),
 								Integer.parseInt(level));
 					}
 				}
 			}
 
-			if (item.hasPotionEffect()) {
-				item.applyPotionMeta((PotionMeta) itemMeta);
-			}
+			itemStack.setItemMeta(itemMeta);
 
-			gItem.getItem().setItemMeta(itemMeta);
+			if (item.hasPotion()) {
+				item.getPotion().apply(itemStack);
+			}
 
 			page.setItem(gItem, x);
 			qty.put(x, multiplier);

--- a/src/com/pablo67340/guishop/listenable/Sell.java
+++ b/src/com/pablo67340/guishop/listenable/Sell.java
@@ -77,7 +77,16 @@ public final class Sell {
 		if (couldntSell) {
 			player.sendMessage(Config.getPrefix() + " " + Config.getCantSell().replace("{count}", countSell + ""));
 		}
-
+		roundAndGiveMoney(player, moneyToGive);
+	}
+	
+	/**
+	 * Rounds the amount and deposits it on behalf of the player.
+	 * 
+	 * @param player the player
+	 * @param moneyToGive the amount to give
+	 */
+	public static void roundAndGiveMoney(Player player, double moneyToGive) {
 		Double moneyToGiveRounded = (double) Math.round(moneyToGive * 100) / 100;
 
 		if (moneyToGiveRounded > 0) {

--- a/src/com/pablo67340/guishop/listenable/Sell.java
+++ b/src/com/pablo67340/guishop/listenable/Sell.java
@@ -1,7 +1,5 @@
 package com.pablo67340.guishop.listenable;
 
-import org.bukkit.ChatColor;
-
 import org.bukkit.entity.Player;
 
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -22,7 +20,7 @@ public final class Sell {
 	 * Open the {@link Sell} GUI.
 	 */
 	public void open(Player player) {
-		GUI = new Gui(Main.getINSTANCE(), 6, ChatColor.translateAlternateColorCodes('&', Config.getSellTitle()));
+		GUI = new Gui(Main.getINSTANCE(), 6, Config.getSellTitle());
 		GUI.setOnClose(this::onSellClose);
 		StaticPane pane = new StaticPane(0, 0, 9, 6);
 		GUI.addPane(pane);

--- a/src/com/pablo67340/guishop/listenable/Shop.java
+++ b/src/com/pablo67340/guishop/listenable/Shop.java
@@ -460,7 +460,11 @@ public class Shop {
 			}
 
 			if (item.getItemType() == ItemType.SHOP) {
-				new Quantity(item, this, player).loadInventory().open();
+				if (Config.isAlternateSellEnabled() && item.hasSellPrice() && (e.getClick() == ClickType.RIGHT || e.getClick() == ClickType.SHIFT_RIGHT)) {
+					new AltSell(item).open(player);
+				} else {
+					new Quantity(item, this, player).loadInventory().open();
+				}
 			} else if (item.getItemType() == ItemType.COMMAND) {
 
 				double priceToPay;

--- a/src/com/pablo67340/guishop/listenable/Shop.java
+++ b/src/com/pablo67340/guishop/listenable/Shop.java
@@ -455,7 +455,12 @@ public class Shop {
 				return;
 
 			} else if (!item.hasBuyPrice()) {
-				player.sendMessage(Config.getPrefix() + " " + Config.getCannotBuy());
+
+				if (Config.isAlternateSellEnabled() && item.hasSellPrice() && (e.getClick() == ClickType.RIGHT || e.getClick() == ClickType.SHIFT_RIGHT)) {
+					new AltSell(item).open(player);
+				} else {
+					player.sendMessage(Config.getPrefix() + " " + Config.getCannotBuy());
+				}
 				return;
 			}
 

--- a/src/com/pablo67340/guishop/listenable/Shop.java
+++ b/src/com/pablo67340/guishop/listenable/Shop.java
@@ -13,7 +13,6 @@ import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.*;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.scheduler.BukkitScheduler;
 
 import com.github.stefvanschie.inventoryframework.Gui;
@@ -153,8 +152,9 @@ public class Shop {
 					if (item.isAnyPotion()) {
 						ConfigurationSection potionSection = section.getConfigurationSection("potion-info");
 						if (potionSection != null) {
-							item.setAndParsePotionType(potionSection.getString("type"),
-									potionSection.getInt("duration", -1), potionSection.getInt("amplifier", -1));
+							item.parsePotionType(potionSection.getString("type"),
+									potionSection.getBoolean("splash", false),
+									potionSection.getBoolean("extended", false), potionSection.getInt("amplifier", -1));
 						}
 					}
 					item.setMobType((section.contains("mobType") ? (String) section.get("mobType") : null));
@@ -197,6 +197,7 @@ public class Shop {
 
 	}
 
+	@SuppressWarnings("deprecation")
 	private void loadShop() {
 		Integer index = 0;
 		ShopPane page = new ShopPane(9, 6);
@@ -218,7 +219,8 @@ public class Shop {
 			// Null items as there is a item type switch in the lines above.
 			if (item.getItemType() == ItemType.SHOP || item.getItemType() == ItemType.COMMAND) {
 
-				ItemMeta itemMeta = gItem.getItem().getItemMeta();
+				ItemStack itemStack = gItem.getItem();
+				ItemMeta itemMeta = itemStack.getItemMeta();
 
 				List<String> lore = new ArrayList<>();
 
@@ -256,18 +258,18 @@ public class Shop {
 						for (String enc : item.getEnchantments()) {
 							String enchantment = StringUtils.substringBefore(enc, ":");
 							String level = StringUtils.substringAfter(enc, ":");
-							gItem.getItem().addUnsafeEnchantment(
+							itemStack.addUnsafeEnchantment(
 									XEnchantment.matchXEnchantment(enchantment).get().parseEnchantment(),
 									Integer.parseInt(level));
 						}
 					}
 				}
 
-				if (item.hasPotionEffect()) {
-					item.applyPotionMeta((PotionMeta) itemMeta);
-				}
+				itemStack.setItemMeta(itemMeta);
 
-				gItem.getItem().setItemMeta(itemMeta);
+				if (item.hasPotion()) {
+					item.getPotion().apply(itemStack);
+				}
 
 			}
 

--- a/src/com/pablo67340/guishop/util/Config.java
+++ b/src/com/pablo67340/guishop/util/Config.java
@@ -15,7 +15,8 @@ public final class Config {
 	 */
 	@Getter
 	@Setter
-	private static boolean registerCommands, signsOnly, escapeOnly, soundEnabled, enableCreator, dynamicPricing, debugMode;
+	private static boolean registerCommands, signsOnly, escapeOnly, alternateSellEnabled, soundEnabled, enableCreator,
+			dynamicPricing, debugMode;
 	
 	@Getter
 	private static List<String> disabledQty = new ArrayList<>();
@@ -27,9 +28,19 @@ public final class Config {
 	@Getter
 	@Setter
 	private static String added, cantSell, cantBuy, prefix, purchased, menuName, notEnoughPre, notEnoughPost, signTitle,
-			sellCommand, menuTitle, shopTitle, sellTitle, sold, taken, sound, full, currency, noPermission, qtyTitle,
-			currencySuffix, backButtonItem, backButtonText, cannotSell, cannotBuy, buyLore, sellLore, freeLore,
-			forwardPageButtonName, backwardPageButtonName;
+			sellCommand, menuTitle, shopTitle, sellTitle, altSellTitle, sold, taken, sound, full, currency,
+			noPermission, qtyTitle, currencySuffix, backButtonItem, backButtonText, cannotSell, cannotBuy, buyLore,
+			sellLore, freeLore, forwardPageButtonName, backwardPageButtonName, altSellAddMaterial,
+			altSellRemoveMaterial, altSellIndicatorMaterial, altSellConfirmMaterial, altSellCancelMaterial,
+			altSellConfirmName, altSellCancelName, altSellNotEnough;
+	
+	/**
+	 * Integers from the config
+	 * 
+	 */
+	@Getter
+	@Setter
+	private static int altSellQuantity1, altSellQuantity2, altSellQuantity3;
 
 	/**
 	 * Number of rows for the {@link Menu} GUI.


### PR DESCRIPTION
A user in the Discord requested an alternate sell GUI, which, if enabled, is accessed by right-clicking an item in the shop. [A demonstration is shown here](https://www.youtube.com/watch?v=LgxdRfuK7Ss). The alternate sell GUI is an addition to, not a replacement for, good old /sell.

There is only 1 caveat with the alternate sell GUI. I could not get it to use the escape button as a back button. Still, for those who want it, it's much better to have a GUI without a back button than no GUI at all. If another developer knows a solution to this minor detail, it may be added.