### PR TITLE
Fixed an issue with spawners on some versions, Small improvements

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: GUIShop
 main: com.pablo67340.guishop.Main
-version: 7.3.9
+version: ${project.version}
 author: pablo67340
 description: Shop Plugin for any server.
 depend: [Vault]

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<!-- Project information -->
 	<groupId>com.pablo67340.GUIShop</groupId>
 	<artifactId>GUIShop</artifactId>
-	<version>7.3.9</version>
+	<version>8.0</version>
 	<name>GUIShop</name>
 	<url>https://www.spigotmc.org/resources/guishop.2451/</url>
 	<description>This plugin is the ultimate solution to all the signs, the chests, the glitches.</description>

--- a/src/com/pablo67340/guishop/Main.java
+++ b/src/com/pablo67340/guishop/Main.java
@@ -355,6 +355,10 @@ public final class Main extends JavaPlugin {
 		for (String shop : Main.getINSTANCE().getCustomConfig().getKeys(false)) {
 
 			ConfigurationSection config = Main.getINSTANCE().getCustomConfig().getConfigurationSection(shop);
+			if (config == null) {
+				log("Check the section for shop " + shop + " in the shops.yml. It was not found.");
+				continue;
+			}
 
 			assert config != null;
 			for (String str : config.getKeys(false)) {
@@ -362,6 +366,10 @@ public final class Main extends JavaPlugin {
 				Item item = new Item();
 
 				ConfigurationSection section = config.getConfigurationSection(str);
+				if (section == null) {
+					log("Check the config section for item " + str + " in shop " + shop + " the shops.yml. It is not a valid section.");
+					continue;
+				}
 
 				item.setMaterial((section.contains("id") ? (String) section.get("id") : "AIR"));
 				if (item.isAnyPotion()) {

--- a/src/com/pablo67340/guishop/definition/Item.java
+++ b/src/com/pablo67340/guishop/definition/Item.java
@@ -227,7 +227,11 @@ public final class Item {
 	 * @return if the item
 	 */
 	public boolean isMobSpawner() {
-		return material.equalsIgnoreCase(SPAWNER_MATERIAL);
+		if (material.equalsIgnoreCase(SPAWNER_MATERIAL)) {
+			return true;
+		}
+		XMaterial spawnerXMaterial = XMaterial.SPAWNER;
+		return material.equalsIgnoreCase(spawnerXMaterial.name()) || spawnerXMaterial.anyMatchLegacy(material);
 	}
 
 	/**

--- a/src/com/pablo67340/guishop/listenable/PlayerListener.java
+++ b/src/com/pablo67340/guishop/listenable/PlayerListener.java
@@ -110,18 +110,20 @@ public final class PlayerListener implements Listener {
 	 */
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockPlace(BlockPlaceEvent event) {
-		if (Item.isSpawnerItem(event.getItemInHand())) {
+		ItemStack item = event.getItemInHand();
+		if (Item.isSpawnerItem(item)) {
 
-			BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
-			scheduler.scheduleSyncDelayedTask(Main.getINSTANCE(), () -> {
-				ItemStack item = event.getItemInHand();
-				NBTTagCompound cmp = ItemNBTUtil.getTag(item);
-				if (cmp.hasKey("GUIShopSpawner")) {
+			NBTTagCompound cmp = ItemNBTUtil.getTag(item);
+			if (cmp.hasKey("GUIShopSpawner")) {
+
+				BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
+				scheduler.scheduleSyncDelayedTask(Main.getINSTANCE(), () -> {
 
 					String mobId = cmp.getString("GUIShopSpawner");
 					Block block = event.getBlockPlaced();
 					CreatureSpawner cs = (CreatureSpawner) block.getState();
 
+					Main.debugLog("Applying mob type " + mobId);
 					/*
 					 * Although valueOf is almost always safe here because
 					 * we used EntityType.name() when setting the NBT tag,
@@ -134,9 +136,9 @@ public final class PlayerListener implements Listener {
 					} catch (IllegalArgumentException veryRareException) {
 						Main.log("Detected outdated mob spawner ID: " + mobId + " placed by " + event.getPlayer());
 					}
-				}
-			}, 1L);
 
+				}, 1L);
+			}
 		}
 	}
 

--- a/src/com/pablo67340/guishop/listenable/Quantity.java
+++ b/src/com/pablo67340/guishop/listenable/Quantity.java
@@ -316,9 +316,11 @@ class Quantity {
 					Main.log("Invalid EntityType in shops.yml: " + item.getMobType());
 
 				} else {
-					NBTTagCompound tag = ItemNBTUtil.getTag(itemStack);
-					tag.setString("GUIShopSpawner", type.name());
+					String entityValue = type.name();
+					Main.debugLog("Attaching " + entityValue + " to purchased spawner");
 
+					NBTTagCompound tag = ItemNBTUtil.getTag(itemStack);
+					tag.setString("GUIShopSpawner", entityValue);
 					itemStack = ItemNBTUtil.setNBTTag(tag, itemStack);
 				}
 			}

--- a/src/com/pablo67340/guishop/listenable/Shop.java
+++ b/src/com/pablo67340/guishop/listenable/Shop.java
@@ -218,7 +218,7 @@ public class Shop {
 			GuiItem gItem = item.parseMaterial();
 
 			if (gItem == null) {
-				Main.debugLog("Item " + item.getMaterial() + " could not be resolved");
+				Main.debugLog("Item " + item.getMaterial() + " could not be resolved (invalid material)");
 				continue;
 			}
 
@@ -228,6 +228,11 @@ public class Shop {
 
 				ItemStack itemStack = gItem.getItem();
 				ItemMeta itemMeta = itemStack.getItemMeta();
+
+				if (itemMeta == null) {
+					Main.debugLog("Item + " + item.getMaterial() + " could not be resolved (null meta)");
+					continue;
+				}
 
 				List<String> lore = new ArrayList<>();
 

--- a/src/com/pablo67340/guishop/listenable/Shop.java
+++ b/src/com/pablo67340/guishop/listenable/Shop.java
@@ -139,12 +139,19 @@ public class Shop {
 
 			ConfigurationSection config = Main.getINSTANCE().getCustomConfig().getConfigurationSection(shop);
 
-			if (config != null) {
+			if (config == null) {
+				Main.log("Check the section for shop " + shop + " in the shops.yml. It was not found.");
+
+			} else {
 				for (String str : config.getKeys(false)) {
 
 					Item item = new Item();
 
 					ConfigurationSection section = config.getConfigurationSection(str);
+					if (section == null) {
+						Main.log("Check the config section for item " + str + " in shop " + shop + " in the shops.yml. It is not a valid section.");
+						continue;
+					}
 
 					item.setSlot((Integer.parseInt(str)));
 


### PR DESCRIPTION
* Solved an odd mob spawner-related version-specific bug a couple of users were experiencing, specifically on 1.12.2.
* Minor improvements for user experience, such as skipping shops not defined and items with null meta to prevent NPEs when GUIShop starts up. All of these mishaps will print a message to inform users of the mistake.
* Replaced plugin.yml version with `${project.version}` so that version increments are simpler