### PR TITLE
Send transaction message for command-based items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
 		<repository>
-			<id>arim-repo</id>
-			<url>https://dl.cloudsmith.io/public/anand-beh/arim-repo/maven/</url>
+			<id>arim-mvn-lgpl3</id>
+			<url>https://mvn-repo.arim.space/lesser-gpl3/</url>
 		</repository>
 		<repository>
 			<id>jitpack.io</id>
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>space.arim</groupId>
 			<artifactId>legacyitemconstructor</artifactId>
-			<version>0.1.1-SNAPSHOT</version>
+			<version>0.1.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -114,7 +114,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
+				<version>3.8.1</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
@@ -123,7 +123,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
-				<version>2.3</version>
+				<version>3.2.4</version>
 				<configuration>
 					<artifactSet>
 						<includes>

--- a/src/com/pablo67340/guishop/Main.java
+++ b/src/com/pablo67340/guishop/Main.java
@@ -140,8 +140,8 @@ public final class Main extends JavaPlugin {
 		}
 
 		getServer().getPluginManager().registerEvents(PlayerListener.INSTANCE, this);
-		getServer().getPluginCommand("guishop").setExecutor(new GuishopCommand());
-		getServer().getPluginCommand("guishopuser").setExecutor(new GuishopUserCommand());
+		getCommand("guishop").setExecutor(new GuishopCommand());
+		getCommand("guishopuser").setExecutor(new GuishopUserCommand());
 		loadDefaults();
 		if (Config.isDynamicPricing() && !setupDynamicPricing()) {
 			getLogger().log(Level.INFO, "Could not find a DynamicPriceProvider! Disabling dynamic pricing...");
@@ -242,7 +242,7 @@ public final class Main extends JavaPlugin {
 	}
 
 	public GuishopUserCommand getUserCommands() {
-		return (GuishopUserCommand) getServer().getPluginCommand("guishopuser").getExecutor();
+		return (GuishopUserCommand) getCommand("guishopuser").getExecutor();
 	}
 
 	/**

--- a/src/com/pablo67340/guishop/definition/CommandsMode.java
+++ b/src/com/pablo67340/guishop/definition/CommandsMode.java
@@ -28,7 +28,7 @@ public enum CommandsMode {
 			// Fallback to legacy option register-commands
 			return (Main.getINSTANCE().getMainConfig().getBoolean("register-commands", true)) ? REGISTER : NONE;
 		}
-		switch (cmdsModeStr.toLowerCase()) {
+		switch (cmdsModeStr.toUpperCase()) {
 		case "INTERCEPT":
 			return INTERCEPT;
 		case "REGISTER":

--- a/src/com/pablo67340/guishop/listenable/Shop.java
+++ b/src/com/pablo67340/guishop/listenable/Shop.java
@@ -506,6 +506,9 @@ public class Shop {
 						Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(),
 								Main.placeholderIfy(str, player, item));
 					});
+					player.sendMessage(Config.getPrefix() + Config.getPurchased() + priceToPay + Config.getTaken()
+							+ Config.getCurrencySuffix());
+
 					if (dynamicPricingUpdate != null) {
 						dynamicPricingUpdate.run();
 					}


### PR DESCRIPTION
At the moment, a config message (typically "You have received $x for purchased items") is sent when a transaction via the Quantity GUI is completed.

This PR adds the same message when command-based items are purchased.

There's also a very minor change with respect to plugin commands, which will in all likelihood not affect anyone, but it's important to be correct.