### PR TITLE
Fix console spam for missing config entry and not applying names in the menu

### DIFF
--- a/menu.yml
+++ b/menu.yml
@@ -23,42 +23,55 @@ Menu:
                 '0':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '1':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '2':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '3':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '4':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '5':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '6':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '7':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '8':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '9':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '10':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '11':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '12':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '13':
                   id: BREWING_STAND
                   lore:
@@ -69,24 +82,31 @@ Menu:
                 '14':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '15':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '16':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '17':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '18':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '19':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '20':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '21':
                   id: TNT
                   lore:
@@ -111,18 +131,23 @@ Menu:
                 '24':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '25':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '26':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '27':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '28':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '29':
                   id: SPAWNER
                   lore:
@@ -155,104 +180,137 @@ Menu:
                 '34':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '35':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '36':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '37':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '38':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '39':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '40':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '41':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '42':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '43':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '44':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '45':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '46':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '47':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '48':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '49':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '50':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '51':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '52':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '53':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
         Page1:
             items:
                 '0':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '1':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '2':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '3':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '4':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '5':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '6':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '7':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '8':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '9':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '10':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '11':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '12':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '13':
                   id: PLAYER_HEAD
                   skull-uuid: 'bb6bccb6-cd90-4844-9b1b-60722b1823ae'
@@ -264,24 +322,31 @@ Menu:
                 '14':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '15':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '16':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '17':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '18':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '19':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '20':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '21':
                   id: POTION
                   potion-info:
@@ -311,18 +376,23 @@ Menu:
                 '24':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '25':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '26':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '27':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '28':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '29':
                   id: BOW
                   lore:
@@ -333,6 +403,7 @@ Menu:
                 '30':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '31':
                   id: CREEPER_SPAWN_EGG
                   lore:
@@ -343,6 +414,7 @@ Menu:
                 '32':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '33':
                   id: POPPY
                   lore:
@@ -353,60 +425,80 @@ Menu:
                 '34':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '35':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '36':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '37':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '38':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '39':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '40':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '41':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '42':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '43':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '44':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '45':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '46':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '47':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '48':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '49':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '50':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '51':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '52':
                   id: BLUE_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''
                 '53':
                   id: RED_STAINED_GLASS_PANE
                   name: ' '
+                  target-shop: ''

--- a/src/com/pablo67340/guishop/listenable/Menu.java
+++ b/src/com/pablo67340/guishop/listenable/Menu.java
@@ -225,7 +225,6 @@ public final class Menu {
             GUI.setOnClose(event -> onClose(event));
         }
         GUI.show(player);
-
     }
 
     /**
@@ -237,6 +236,7 @@ public final class Menu {
 
         e.setCancelled(true);
 
+        // Next Buttom
         if (e.getSlot() == Main.getINSTANCE().getMenuConfig().getInt("Menu.nextButtonSlot")) {
             hasClicked = true;
             if (hasMultiplePages() && this.currentPane.getPage() != (this.currentPane.getPages() - 1)) {
@@ -273,6 +273,7 @@ public final class Menu {
         } else if (e.getSlot() == (this.GUI.getInventory().getSize() - 1) && !ConfigUtil.isDisableBackButton()) {
             pl.closeInventory();
         } else {
+            // Everything else<
             if (Main.getINSTANCE().getLoadedMenu().getPages().containsKey("Page" + currentPane.getPage()) && Main.getINSTANCE().getLoadedMenu().getPages().get("Page" + currentPane.getPage()).getItems().containsKey(((Integer) e.getSlot()).toString())) {
                 Item clickedItem = Main.getINSTANCE().getLoadedMenu().getPages().get("Page" + currentPane.getPage()).getItems().get(((Integer) e.getSlot()).toString());
                 String shopName = clickedItem.getTargetShop();
@@ -301,8 +302,6 @@ public final class Menu {
             Shop openShop = new Shop(player, shop, this);
             openShop.loadItems(false);
             openShop.open(player);
-        } else {
-            Main.log("Error: Target shop of clicked item not specified. Please add target-shop to specific item in menu.yml to fix this.");
         }
     }
 

--- a/src/com/pablo67340/guishop/listenable/Menu.java
+++ b/src/com/pablo67340/guishop/listenable/Menu.java
@@ -273,7 +273,7 @@ public final class Menu {
         } else if (e.getSlot() == (this.GUI.getInventory().getSize() - 1) && !ConfigUtil.isDisableBackButton()) {
             pl.closeInventory();
         } else {
-            // Everything else<
+            // Everything else
             if (Main.getINSTANCE().getLoadedMenu().getPages().containsKey("Page" + currentPane.getPage()) && Main.getINSTANCE().getLoadedMenu().getPages().get("Page" + currentPane.getPage()).getItems().containsKey(((Integer) e.getSlot()).toString())) {
                 Item clickedItem = Main.getINSTANCE().getLoadedMenu().getPages().get("Page" + currentPane.getPage()).getItems().get(((Integer) e.getSlot()).toString());
                 String shopName = clickedItem.getTargetShop();


### PR DESCRIPTION
This commit fixes the console spam when the config entry "target-shop" isn't set and fixes that names don't apply when the previosly mentioned entry doesn't exist. Edited menu.yml too to fit the requirements.