### PR TITLE
Enable dynamic pricing for Item by default.

### DIFF
--- a/src/com/pablo67340/guishop/definition/Item.java
+++ b/src/com/pablo67340/guishop/definition/Item.java
@@ -95,7 +95,7 @@ public final class Item implements ConfigurationSerializable {
      */
     @Getter
     @Setter
-    private boolean useDynamicPricing;
+    private boolean useDynamicPricing = true;
 
     @Getter
     @Setter


### PR DESCRIPTION
For dynamic price to work `useDynamicPricing` field in Item.class must be true. But from my quick analysis I think there is no way to set it to true (no config option for item, nothing). This is a quick workaround to get dynamic pricing work until there will be a (config?) way to do it.
So now if player enable dynamic pricing in config, it will work for all items (what is maybe desirable).