### PR TITLE
Add BetterReload support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 author: pablo67340
 description: Shop Plugin for any server.
 depend: [Vault]
+softdepend: [BetterReload]
 api-version: 1.13
 permissions:
     guishop.use:

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,12 @@
             <artifactId>item-nbt-api-plugin</artifactId>
             <version>2.13.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.amnoah</groupId>
+            <artifactId>BetterReload</artifactId>
+            <version>API-v1.0.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <defaultGoal>clean install</defaultGoal>

--- a/src/com/pablo67340/guishop/GUIShop.java
+++ b/src/com/pablo67340/guishop/GUIShop.java
@@ -11,6 +11,7 @@ import com.pablo67340.guishop.listenable.Menu;
 import com.pablo67340.guishop.listenable.PlayerListener;
 import com.pablo67340.guishop.listenable.Sell;
 import com.pablo67340.guishop.listenable.Shop;
+import com.pablo67340.guishop.listenable.ReloadListener;
 import com.pablo67340.guishop.util.ConfigManager;
 import com.pablo67340.guishop.util.LogUtil;
 import com.pablo67340.guishop.util.MiscUtils;
@@ -112,6 +113,10 @@ public final class GUIShop extends JavaPlugin {
         getServer().getPluginManager().registerEvents(PlayerListener.INSTANCE, this);
         getServer().getPluginCommand("guishop").setExecutor(new GuishopCommand());
         getServer().getPluginCommand("guishopuser").setExecutor(new UserCommand());
+
+        if (getServer().getPluginManager().getPlugin("BetterReload") != null) {
+            getServer().getPluginManager().registerEvents(ReloadListener.INSTANCE, this);
+        }
     }
 
     public UserCommand getUserCommands() {

--- a/src/com/pablo67340/guishop/listenable/ReloadListener.java
+++ b/src/com/pablo67340/guishop/listenable/ReloadListener.java
@@ -1,0 +1,21 @@
+package com.pablo67340.guishop.listenable;
+
+import better.reload.api.ReloadEvent;
+import com.pablo67340.guishop.GUIShop;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class ReloadListener implements Listener {
+
+    /**
+     * An instance of a {@link ReloadListener} that will be used to handle this
+     * specific object reference from other classes, even though methods here
+     * will be static.
+     */
+    public static final ReloadListener INSTANCE = new ReloadListener();
+
+    @EventHandler
+    public void onReload(ReloadEvent event) {
+        GUIShop.getINSTANCE().reload(event.getCommandSender(), false);
+    }
+}


### PR DESCRIPTION
Recently I read about an interesting issue regarding the Bukkit `/reload` command where one of GUIShop's classes was [unable to be casted to itself](https://gist.github.com/A248/0085b1dff1bd3f93876e435d0d10b5d4). This is one of many ridiculous problems I've seen with the Bukkit `/reload` command - and one of many that I'm hoping to prevent.

This pull request adds support for [BetterReload](https://github.com/amnoah/BetterReload) - a plugin that overrides the `/reload` command and sends out an event in its place to plugins that can either be handled or ignored. This leaves the reloading process up to plugins and leaves no sketchy behavior in the process.

This is a completely optional dependency, only having any function when the BetterReload plugin is installed alongside GUIShop.

For more information about BetterReload here are some links:
[Source Code](https://github.com/amnoah/BetterReload)
[Documentation](https://github.com/amnoah/BetterReload/wiki)
[SpigotMC](https://www.spigotmc.org/resources/betterreload.111256/)
[Modrinth](https://modrinth.com/plugin/betterreload)

Thank you so much for your time, and have a great day!